### PR TITLE
fix: support non-interactive install (no TTY)

### DIFF
--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -21,15 +21,56 @@ function getVersion() {
   }
 }
 
-export default async function install() {
+// Parser simples de flags para instalação não-interativa (sem TTY).
+// Ex.: --yes --engines=claude-code,codex --teams=core,visual
+//      --project-name="Meu Projeto" --user-name=Ana --chat-language=pt-br
+//      --git-strategy=gitignore
+function parseInstallArgs(args = []) {
+  const overrides = {};
+  for (const arg of args) {
+    if (arg === '--yes' || arg === '-y') {
+      overrides.yes = true;
+      continue;
+    }
+    const match = arg.match(/^--([a-z-]+)=(.*)$/);
+    if (!match) continue;
+    const [, key, value] = match;
+    switch (key) {
+      case 'engines':
+        overrides.engines = value.split(',').map(s => s.trim()).filter(Boolean);
+        break;
+      case 'teams':
+        overrides.teams = value.split(',').map(s => s.trim()).filter(Boolean);
+        break;
+      case 'project-name':
+        overrides.projectName = value;
+        break;
+      case 'user-name':
+        overrides.userName = value;
+        break;
+      case 'chat-language':
+        overrides.chatLanguage = value;
+        break;
+      case 'git-strategy':
+        overrides.gitStrategy = value;
+        break;
+    }
+  }
+  return overrides;
+}
+
+export default async function install(args = []) {
   const { default: chalk } = await import('chalk');
   const { default: ora } = await import('ora');
+
+  const overrides = parseInstallArgs(args);
+  const interactive = Boolean(process.stdin.isTTY) && !overrides.yes;
 
   const projectRoot = resolve(process.cwd());
   const version = getVersion();
   const DEFAULT_THEME = 'mira-dark'; // tema base fixo; a escolha de tema/template é por deck no /mira-new
 
-  console.clear();
+  if (interactive) console.clear();
   console.log(chalk.hex('#FF904D')(renderMiraLogo()));
   console.log(chalk.gray('  Slides animados — direto das suas fontes.'));
   console.log('');
@@ -38,17 +79,21 @@ export default async function install() {
   const existing = checkExistingInstallation(projectRoot);
   if (existing.installed) {
     console.log(chalk.yellow(`\n  O Mira já está instalado (v${existing.version}) nesta pasta.`));
-    const { default: inquirer } = await import('inquirer');
-    const { proceed } = await inquirer.prompt([{
-      prefix: '',
-      type: 'confirm',
-      name: 'proceed',
-      message: '\nReinstalar / atualizar a configuração?',
-      default: false,
-    }]);
-    if (!proceed) {
-      console.log(chalk.gray('\n  Instalação cancelada.\n'));
-      return;
+    if (!interactive) {
+      console.log(chalk.gray('  Sem TTY / --yes: atualizando configuração automaticamente.'));
+    } else {
+      const { default: inquirer } = await import('inquirer');
+      const { proceed } = await inquirer.prompt([{
+        prefix: '',
+        type: 'confirm',
+        name: 'proceed',
+        message: '\nReinstalar / atualizar a configuração?',
+        default: false,
+      }]);
+      if (!proceed) {
+        console.log(chalk.gray('\n  Instalação cancelada.\n'));
+        return;
+      }
     }
   }
 
@@ -56,11 +101,14 @@ export default async function install() {
   const detected = detectedEngines.filter(e => e.detected).map(e => e.name).join(', ');
   if (detected) console.log(chalk.gray(`\n  Engines detectadas: ${detected}`));
 
-  const answers = await runInstallPrompts(detectedEngines);
+  const answers = await runInstallPrompts(detectedEngines, overrides);
   console.log('');
 
   const writer = new Writer(projectRoot);
-  const selectedEngines = ENGINES.filter(e => answers.engines.includes(e.id));
+  let selectedEngines = ENGINES.filter(e => answers.engines.includes(e.id));
+  if (selectedEngines.length === 0) {
+    selectedEngines = ENGINES.filter(e => e.id === 'claude-code');
+  }
 
   // 1. Agents por engine
   let spinner = ora('  Instalando agents...').start();

--- a/lib/installer/prompts.js
+++ b/lib/installer/prompts.js
@@ -13,7 +13,28 @@ const promptTitle = (number, message, suffix = 'none') => {
   return `\n${number}. ${message}${tail}`;
 };
 
-export async function runInstallPrompts(detectedEngines) {
+export async function runInstallPrompts(detectedEngines, overrides = {}) {
+  const interactive = Boolean(process.stdin.isTTY) && !overrides.yes;
+
+  if (!interactive) {
+    const detectedIds = detectedEngines.filter(e => e.detected).map(e => e.id);
+    const engines = overrides.engines?.length ? overrides.engines : (detectedIds.length ? detectedIds : ['claude-code']);
+    const teams = overrides.teams?.length ? overrides.teams : ['core', 'visual'];
+
+    const agents = [...PIPELINE_CORE];
+    if (teams.includes('visual')) agents.push(...VISUAL_TEAM);
+
+    return {
+      engines,
+      teams,
+      project_name: overrides.projectName || process.cwd().split(/[\\/]/).pop(),
+      user_name: overrides.userName || 'usuário',
+      chat_language: overrides.chatLanguage || 'pt-br',
+      git_strategy: overrides.gitStrategy || 'commit',
+      agents: [...new Set(agents)],
+    };
+  }
+
   const engineChoices = detectedEngines.map(e => ({
     name: `${e.name}${e.star ? ' (recomendado)' : ''}`,
     value: e.id,
@@ -84,6 +105,8 @@ export async function runInstallPrompts(detectedEngines) {
 }
 
 export async function askMergeStrategy(filePath) {
+  if (!process.stdin.isTTY) return 'skip';
+
   const { strategy } = await inquirer.prompt([
     {
       ...P,


### PR DESCRIPTION
Fixes #1

## Problem

`npx mira-animator install` crashes with `ERR_USE_AFTER_CLOSE: readline was closed` when stdin is not a TTY (CI, Docker, headless VPS via SSH). `runInstallPrompts()` calls `inquirer.prompt()` unconditionally; without a TTY the readline interface closes before the prompt resolves.

## Fix

- `lib/installer/prompts.js`
  - `runInstallPrompts(detectedEngines, overrides)`: when `!process.stdin.isTTY` or `overrides.yes`, skips inquirer and returns defaults (detected engines, falling back to `claude-code`; both agent teams; `pt-br`; `commit` git strategy), all overridable.
  - `askMergeStrategy()`: returns `'skip'` without a TTY, so an existing entry file (`CLAUDE.md`, `AGENTS.md`, ...) is never clobbered non-interactively.
- `lib/commands/install.js`
  - New `parseInstallArgs()`: `--yes`/`-y`, `--engines=a,b`, `--teams=core,visual`, `--project-name=`, `--user-name=`, `--chat-language=`, `--git-strategy=commit|gitignore`.
  - The "already installed, reinstall?" confirm is skipped (auto-yes) without a TTY.
  - `console.clear()` only runs when interactive.
  - Falls back to `claude-code` if `--engines` resolves to an empty/invalid set.

## Testing

```
cd /tmp/mira-test
node bin/mira.js install --yes      # clean install, no TTY, no prompts
node bin/mira.js status             # 23 agents, 80/80 files intact
node bin/mira.js install            # reinstall without --yes, non-TTY stdin: still works
```

All three ran clean on a headless Ubuntu VPS (no DISPLAY, non-interactive shell).