### PR TITLE
[codex] Add Codex plugin wrapper

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "mira-animator",
+  "interface": {
+    "displayName": "Mira Animator"
+  },
+  "plugins": [
+    {
+      "name": "mira-animator",
+      "source": {
+        "source": "local",
+        "path": "./plugins/mira-animator"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -152,6 +152,19 @@ npx mira-animator uninstall          # remove Mira from the current folder
 
 ---
 
+## Codex plugin
+
+Mira also includes a local Codex plugin wrapper in `plugins/mira-animator/`. To install it from a clone of this repository:
+
+```bash
+codex plugin marketplace add .
+codex plugin add mira-animator@mira-animator
+```
+
+After installing, start a new Codex thread and ask Codex to use the `mira-animator` plugin. Full instructions are in the [Codex plugin docs](docs/codex-plugin.md).
+
+---
+
 ## Contributing
 
 Contributions are welcome. Open an issue to discuss before submitting a PR.

--- a/docs/codex-plugin.es.md
+++ b/docs/codex-plugin.es.md
@@ -1,0 +1,47 @@
+# Plugin de Codex
+
+Mira incluye un wrapper de plugin local para Codex en `plugins/mira-animator/`. El plugin ayuda a Codex a preparar Mira en una carpeta dedicada de slides, vincular fuentes de solo lectura, crear decks y seguir el flujo de validación de Mira.
+
+El plugin no cambia el runtime del paquete npm. Se distribuye desde este repositorio como una entrada de marketplace local de Codex.
+
+## Instalar desde este repositorio
+
+Clona el repositorio y registra su marketplace local:
+
+```bash
+git clone https://github.com/sandeco/mira-animator.git
+cd mira-animator
+codex plugin marketplace add .
+codex plugin add mira-animator@mira-animator
+```
+
+Después de instalarlo, inicia una nueva conversación en Codex para que Codex cargue los metadatos de la skill del plugin.
+
+## Usar el plugin
+
+Pide a Codex que use Mira, por ejemplo:
+
+```text
+Usa el plugin mira-animator para preparar una carpeta de slides para este proyecto.
+```
+
+El plugin debe guiar a Codex para:
+
+1. Elegir o crear una carpeta dedicada de slides.
+2. Verificar que Node.js sea 18.20.2 o superior.
+3. Ejecutar `npx mira-animator install` dentro de la carpeta de slides.
+4. Incluir la engine `Codex` cuando el instalador de Mira pregunte qué engines debe soportar.
+5. Vincular proyectos o documentos fuente con `npx mira-animator link`.
+6. Crear y validar decks dentro de `decks/`.
+
+## Regla importante de aislamiento
+
+No instales Mira dentro del proyecto fuente que quieres presentar, salvo que esa carpeta sea intencionalmente la carpeta de slides. Mira debe leer fuentes vinculadas y escribir la salida generada solo dentro de la carpeta de slides, principalmente en `decks/`.
+
+## Archivos para mantenedores
+
+- `.agents/plugins/marketplace.json` expone el marketplace local del repositorio.
+- `plugins/mira-animator/.codex-plugin/plugin.json` define los metadatos del plugin.
+- `plugins/mira-animator/skills/mira-animator/SKILL.md` define el flujo de Mira orientado a Codex.
+
+El plugin acredita a sandeco como creador de Mira y a Mario Mayerle (`https://mariomayerle.com`) como desarrollador del plugin.

--- a/docs/codex-plugin.md
+++ b/docs/codex-plugin.md
@@ -1,0 +1,47 @@
+# Codex plugin
+
+Mira includes a local Codex plugin wrapper under `plugins/mira-animator/`. The plugin helps Codex bootstrap Mira in a dedicated slides workspace, link sources read-only, create decks, and follow the Mira validation workflow.
+
+The plugin does not change the npm package runtime. It is distributed from this repository as a local Codex marketplace entry.
+
+## Install from this repository
+
+Clone the repository and register its local marketplace:
+
+```bash
+git clone https://github.com/sandeco/mira-animator.git
+cd mira-animator
+codex plugin marketplace add .
+codex plugin add mira-animator@mira-animator
+```
+
+After installing, start a new Codex thread so Codex can load the plugin's skill metadata.
+
+## Use the plugin
+
+Ask Codex to use Mira, for example:
+
+```text
+Use the mira-animator plugin to set up a slides workspace for this project.
+```
+
+The plugin should guide Codex to:
+
+1. Choose or create a dedicated slides workspace.
+2. Check that Node.js is version 18.20.2 or newer.
+3. Run `npx mira-animator install` inside the slides workspace.
+4. Include the `Codex` engine when the Mira installer asks which engines to support.
+5. Link source projects or documents with `npx mira-animator link`.
+6. Create and validate decks under `decks/`.
+
+## Important isolation rule
+
+Do not install Mira inside the source project you want to present unless that folder is intentionally the slides workspace. Mira should read linked sources and write generated output only inside the slides workspace, mainly under `decks/`.
+
+## Files for maintainers
+
+- `.agents/plugins/marketplace.json` exposes the repository-local marketplace.
+- `plugins/mira-animator/.codex-plugin/plugin.json` defines the plugin metadata.
+- `plugins/mira-animator/skills/mira-animator/SKILL.md` defines the Codex-facing Mira workflow.
+
+The plugin credits sandeco as the Mira creator and Mario Mayerle (`https://mariomayerle.com`) as a plugin developer.

--- a/docs/codex-plugin.pt.md
+++ b/docs/codex-plugin.pt.md
@@ -1,0 +1,47 @@
+# Plugin do Codex
+
+O Mira inclui um wrapper de plugin local para o Codex em `plugins/mira-animator/`. O plugin ajuda o Codex a preparar o Mira em uma pasta dedicada de slides, vincular fontes somente leitura, criar decks e seguir o fluxo de validação do Mira.
+
+O plugin não altera o runtime do pacote npm. Ele é distribuído a partir deste repositório como uma entrada de marketplace local do Codex.
+
+## Instalar a partir deste repositório
+
+Clone o repositório e registre o marketplace local:
+
+```bash
+git clone https://github.com/sandeco/mira-animator.git
+cd mira-animator
+codex plugin marketplace add .
+codex plugin add mira-animator@mira-animator
+```
+
+Depois da instalação, abra uma nova conversa no Codex para que ele carregue os metadados da skill do plugin.
+
+## Usar o plugin
+
+Peça ao Codex para usar o Mira, por exemplo:
+
+```text
+Use o plugin mira-animator para preparar uma pasta de slides para este projeto.
+```
+
+O plugin deve orientar o Codex a:
+
+1. Escolher ou criar uma pasta dedicada de slides.
+2. Verificar se o Node.js está na versão 18.20.2 ou superior.
+3. Rodar `npx mira-animator install` dentro da pasta de slides.
+4. Incluir a engine `Codex` quando o instalador do Mira perguntar quais engines devem ser suportadas.
+5. Vincular projetos ou documentos fonte com `npx mira-animator link`.
+6. Criar e validar decks dentro de `decks/`.
+
+## Regra importante de isolamento
+
+Não instale o Mira dentro do projeto fonte que será apresentado, a menos que essa pasta seja intencionalmente a pasta de slides. O Mira deve ler fontes vinculadas e escrever a saída gerada apenas dentro da pasta de slides, principalmente em `decks/`.
+
+## Arquivos para mantenedores
+
+- `.agents/plugins/marketplace.json` expõe o marketplace local do repositório.
+- `plugins/mira-animator/.codex-plugin/plugin.json` define os metadados do plugin.
+- `plugins/mira-animator/skills/mira-animator/SKILL.md` define o fluxo do Mira voltado ao Codex.
+
+O plugin credita sandeco como criador do Mira e Mario Mayerle (`https://mariomayerle.com`) como desenvolvedor do plugin.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,6 +91,7 @@ plugins:
             Transitions: Agentes transições
             Video formats: Formatos de vídeo
             Themes and templates: Temas e templates
+            Codex plugin: Plugin do Codex
             Contributing: Contribuindo
         - locale: es
           name: Español
@@ -111,6 +112,7 @@ plugins:
             Transitions: Agentes transiciones
             Video formats: Formatos de vídeo
             Themes and templates: Temas y plantillas
+            Codex plugin: Plugin de Codex
             Contributing: Contribuir
 
 nav:
@@ -128,4 +130,5 @@ nav:
   - CLI: cli.md
   - Video formats: formatos.md
   - Themes and templates: temas.md
+  - Codex plugin: codex-plugin.md
   - Contributing: contribuindo.md

--- a/plugins/mira-animator/.codex-plugin/plugin.json
+++ b/plugins/mira-animator/.codex-plugin/plugin.json
@@ -1,0 +1,39 @@
+{
+  "name": "mira-animator",
+  "version": "0.1.0",
+  "description": "Use Mira to turn projects, books, PDFs, and notes into animated HTML presentations from Codex.",
+  "author": {
+    "name": "sandeco and Mario Mayerle",
+    "url": "https://mariomayerle.com"
+  },
+  "homepage": "https://sandeco.github.io/mira-animator/",
+  "repository": "https://github.com/sandeco/mira-animator",
+  "license": "MIT",
+  "keywords": [
+    "slides",
+    "presentations",
+    "animation",
+    "html",
+    "d3",
+    "codex"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Mira Animator",
+    "shortDescription": "Create animated HTML slide decks with Mira.",
+    "longDescription": "Mira Animator helps Codex bootstrap and operate Mira in a dedicated slides workspace, link source projects or documents read-only, and generate animated HTML decks with the Mira workflow.",
+    "developerName": "sandeco, Mario Mayerle",
+    "category": "Productivity",
+    "capabilities": [
+      "Interactive",
+      "Write"
+    ],
+    "websiteURL": "https://sandeco.github.io/mira-animator/",
+    "defaultPrompt": [
+      "Set up a Mira slides workspace for this project.",
+      "Create an animated Mira deck from this PDF.",
+      "Link a source folder and start a Mira deck."
+    ],
+    "brandColor": "#FF904D"
+  }
+}

--- a/plugins/mira-animator/skills/mira-animator/SKILL.md
+++ b/plugins/mira-animator/skills/mira-animator/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: mira-animator
+description: Use when a user wants to create animated HTML presentations with Mira, install or update Mira, link folders/PDFs/books as read-only sources, create decks, or manage Mira decks from Codex.
+---
+
+# Mira Animator
+
+Use Mira to turn existing material into animated HTML presentations. Mira's upstream package is `mira-animator` from `https://github.com/sandeco/mira-animator`, with docs at `https://sandeco.github.io/mira-animator/`.
+
+This Codex plugin wrapper credits sandeco as the Mira creator and Mario Mayerle (`https://mariomayerle.com`) as a plugin developer.
+
+## Core Model
+
+- Mira is installed into a dedicated slides working folder, not into the source project being presented.
+- Source projects, PDFs, books, notes, and articles are linked as read-only sources in `mira.config.json`.
+- Generated output belongs in `decks/<deck-name>/`.
+- The normal workflow is: install Mira, link sources, create a deck, fill the deck through the Mira skill pipeline, validate the result.
+
+## Safety Rules
+
+- Never run `npx mira-animator install` inside a source project unless the user explicitly says that folder is the slides workspace.
+- If the current directory looks like a product/repo source folder and the user did not name a slides workspace, create or propose a sibling folder such as `../<project-name>-mira-slides`.
+- Do not edit, move, or delete linked source files. Read from linked sources only.
+- Keep generated files under `decks/`, plus Mira's own workspace files such as `mira.config.json`, `.mira/`, `.agents/skills/`, `AGENTS.md`, and `mira-templates/`.
+- On Windows, use PowerShell syntax and quote paths with spaces.
+
+## Bootstrap
+
+1. Confirm the slides workspace path.
+2. Check Node.js:
+
+```powershell
+node --version
+```
+
+Mira requires Node.js 18.20.2 or newer. If Node is missing or too old, stop and report that blocker.
+
+3. In the slides workspace, install Mira:
+
+```powershell
+npx mira-animator install
+```
+
+When the installer prompts for engines, include `Codex`. Install `Pipeline Core`; include `Visual Team` when the user wants images, charts, screenshots, or visual templates.
+
+4. Verify the install:
+
+```powershell
+npx mira-animator status
+```
+
+Expected workspace files include `mira.config.json`, `AGENTS.md`, `.agents/skills/`, `mira-templates/`, and `decks/`.
+
+If the project-local Mira skills are not available in the current Codex context after install, read the relevant `.agents/skills/<skill-name>/SKILL.md` file directly before doing that step. A new thread may be needed for automatic skill discovery.
+
+## Link Sources
+
+Use `link` from the slides workspace:
+
+```powershell
+npx mira-animator link "C:\path\to\source" --name=source-name
+npx mira-animator sources
+```
+
+Use `--type=projeto`, `--type=pdf`, `--type=latex`, or `--type=texto` only when the type is not obvious or the user asked for a specific type.
+
+## Create Decks
+
+Create the deck shell with the CLI when the requested template and theme are built in:
+
+```powershell
+npx mira-animator new deck-slug --deck=aula-capitulo --theme=mira-dark
+```
+
+Built-in deck templates are `aula-capitulo`, `pitch-projeto`, and `demo-tecnica`.
+Built-in themes are `mira-dark`, `light-minimal`, `corporate-blue`, and `neon-emerald`.
+
+For custom templates or custom themes, follow the local `mira-new` skill instructions from `.agents/skills/mira-new/SKILL.md`.
+
+## Production Workflow
+
+For a full deck, use the local Mira skills in this order:
+
+```text
+mira-new -> mira-extract -> mira-planner -> mira-copywriter -> mira-builder -> mira-animator -> mira-validator
+```
+
+Use support skills when needed:
+
+- `mira-references` for adding source files, pasted text, links, and reference folders.
+- `mira-visuals`, `mira-image-prompt`, `mira-img-animator`, and `mira-chart` for visual assets and data visuals.
+- `mira-3d`, `mira-qrcode`, and `mira-image` for special on-slide elements.
+- `mira-squared`, `mira-vertical`, `mira-thirds`, and `mira-transition-dissolve` for format variants.
+
+Pause for user approval at planning checkpoints unless the user explicitly asked for an unattended run.
+
+## Validation
+
+Before calling the work done:
+
+- Run `npx mira-animator status`.
+- Confirm the generated deck path, usually `decks/<deck-name>/index.html`.
+- Run or read `mira-validator` output when a deck was generated or changed.
+- For visual work, open or screenshot the HTML deck when browser tools are available, checking that slides render, animations are visible, and text is not overlapping.
+
+Report the workspace path, linked sources, deck path, validation summary, and any skipped checks.


### PR DESCRIPTION
## Summary

Adds a repository-local Codex plugin wrapper for Mira without changing the npm runtime/package behavior.

## What changed

- Adds `.agents/plugins/marketplace.json` so the repository can be registered as a local Codex marketplace.
- Adds `plugins/mira-animator/.codex-plugin/plugin.json` with plugin metadata for Mira, crediting sandeco as the Mira creator and Mario Mayerle as a plugin developer.
- Adds `plugins/mira-animator/skills/mira-animator/SKILL.md`, a Codex-facing workflow that keeps Mira installed in a dedicated slides workspace and treats linked sources as read-only.
- Adds Codex plugin installation docs in English, Portuguese, and Spanish, plus a README link.

## Safety / compatibility

- Does not modify `package.json`, `package-lock.json`, installer code, CLI commands, agents, templates, or runtime behavior.
- `npm pack --dry-run` confirms the new `.agents/` and `plugins/` directories are not included in the current npm tarball because `package.json` has an explicit `files` allowlist.

## Validation

- `python scripts/validate_plugin.py C:\Users\mario\plugins\mira-animator`
- `python scripts/validate_plugin.py C:\Users\mario\Documents\INOSX\Products\mira-animator-codex-plugin-pr\plugins\mira-animator`
- `npm pack --dry-run`
- `python -m mkdocs build --strict --site-dir %TEMP%\mira-animator-docs-build` from a temporary venv with `docs/requirements.txt`
- `git diff --cached --check`