### PR TITLE
[codex] adiciona sandeco-just-animation-template

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ You can spell out the template and theme in the same sentence:
 /mira-new create a presentation called 'my-class' with the aula-capitulo template and the mira-dark theme
 ```
 
-**Deck templates:** `aula-capitulo`, `pitch-projeto`, `demo-tecnica`.
+**Deck templates:** `aula-capitulo`, `pitch-projeto`, `demo-tecnica`, `animacao-livre`.
 **Themes:** `mira-dark`, `light-minimal`, `corporate-blue`, `neon-emerald`.
 
 Then, in Claude: *"fill the deck my-class with content from the reversa source"*.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ You can spell out the template and theme in the same sentence:
 /mira-new create a presentation called 'my-class' with the aula-capitulo template and the mira-dark theme
 ```
 
-**Deck templates:** `aula-capitulo`, `pitch-projeto`, `demo-tecnica`, `animacao-livre`.
+**Deck templates:** `aula-capitulo`, `pitch-projeto`, `demo-tecnica`, `sandeco-just-animation-template`.
 **Themes:** `mira-dark`, `light-minimal`, `corporate-blue`, `neon-emerald`.
 
 Then, in Claude: *"fill the deck my-class with content from the reversa source"*.

--- a/agents/mira-animator/SKILL.md
+++ b/agents/mira-animator/SKILL.md
@@ -61,7 +61,7 @@ Textos visíveis em português brasileiro, acentuação 100% correta, UTF-8 dire
 
 ## Onde o Slide é Inserido
 
-Como um novo card dentro do deck do tema, em `slides/<tema>/index.html`. Se o deck ainda não existir, crie a partir de um esqueleto em `mira-templates/decks/` (aula-capitulo, pitch-projeto, demo-tecnica ou animacao-livre), respeitando a estrutura do template escolhido.
+Como um novo card dentro do deck do tema, em `slides/<tema>/index.html`. Se o deck ainda não existir, crie a partir de um esqueleto em `mira-templates/decks/` (aula-capitulo, pitch-projeto, demo-tecnica ou sandeco-just-animation-template), respeitando a estrutura do template escolhido.
 
 ## Estrutura Obrigatória do Card
 

--- a/agents/mira-animator/SKILL.md
+++ b/agents/mira-animator/SKILL.md
@@ -61,7 +61,7 @@ Textos visíveis em português brasileiro, acentuação 100% correta, UTF-8 dire
 
 ## Onde o Slide é Inserido
 
-Como um novo card dentro do deck do tema, em `slides/<tema>/index.html`. Se o deck ainda não existir, crie a partir de um esqueleto em `mira-templates/decks/` (aula-capitulo, pitch-projeto ou demo-tecnica), que já vem com o sistema de passagem de slides embutido.
+Como um novo card dentro do deck do tema, em `slides/<tema>/index.html`. Se o deck ainda não existir, crie a partir de um esqueleto em `mira-templates/decks/` (aula-capitulo, pitch-projeto, demo-tecnica ou animacao-livre), respeitando a estrutura do template escolhido.
 
 ## Estrutura Obrigatória do Card
 

--- a/agents/mira-new/SKILL.md
+++ b/agents/mira-new/SKILL.md
@@ -25,7 +25,7 @@ Tudo o que esta skill cria ou edita vive **dentro de `decks/<tema>/`**. Nunca to
 Pergunte de forma objetiva, oferecendo os defaults entre parênteses. Se o usuário já adiantou alguma resposta no pedido, não pergunte de novo.
 
 1. **Nome do tema.** Texto livre. Gere um **slug** em kebab-case, minúsculo, sem acento (ex.: "Spec Driven Development" → `spec-driven-development`). Confirme o slug com o usuário se houver ambiguidade.
-2. **Template do deck** (esqueleto). Liste **dinamicamente** as opções varrendo `mira-templates/decks/` (cada subpasta com `index.html` é um template). Os built-in são `aula-capitulo` (default), `pitch-projeto`, `demo-tecnica` e `animacao-livre`; templates criados pelo `/mira-image-template` aparecem aqui automaticamente, junto com os existentes. Mostre todos e deixe o usuário escolher.
+2. **Template do deck** (esqueleto). Liste **dinamicamente** as opções varrendo `mira-templates/decks/` (cada subpasta com `index.html` é um template). Os built-in são `aula-capitulo` (default), `pitch-projeto`, `demo-tecnica` e `sandeco-just-animation-template`; templates criados pelo `/mira-image-template` aparecem aqui automaticamente, junto com os existentes. Mostre todos e deixe o usuário escolher.
 3. **Tema base** (identidade visual). Liste **dinamicamente** varrendo `mira-templates/themes/` (cada `.css`, exceto `base.css`, é um tema). Os built-in são `mira-dark` (default, laranja), `light-minimal`, `corporate-blue` e `neon-emerald`; temas gerados pelo `/mira-image-template` aparecem aqui também. **Se o template escolhido tiver um tema de mesmo nome** (caso dos templates derivados de imagem), use-o como **padrão** desse template, pois é a identidade que veio da imagem; o usuário ainda pode escolher outro.
 4. **Cor principal** (opcional). Se o usuário não pedir, use a cor do tema base. Se pedir uma cor (hex `#RRGGBB` ou nome como "roxo"), converta para hex e trate como override no Passo 3. Confirme a cor escolhida.
 5. **Descrição do tema.** Uma ou duas frases: do que trata, para quem, qual o objetivo. Isso vira a semente do briefing.
@@ -35,7 +35,7 @@ Se o deck `decks/<slug>/` já existir, avise e pergunte se é para usar outro no
 
 ### Passo 2: Montar o deck
 
-Para os **templates built-in** (`aula-capitulo`, `pitch-projeto`, `demo-tecnica`, `animacao-livre`) com um **tema built-in**, use o comando canônico do Mira, que copia o esqueleto, injeta o CSS do tema e registra no config:
+Para os **templates built-in** (`aula-capitulo`, `pitch-projeto`, `demo-tecnica`, `sandeco-just-animation-template`) com um **tema built-in**, use o comando canônico do Mira, que copia o esqueleto, injeta o CSS do tema e registra no config:
 
 ```bash
 npx mira-animator new <slug> --deck=<template> --theme=<tema-base>

--- a/agents/mira-new/SKILL.md
+++ b/agents/mira-new/SKILL.md
@@ -25,7 +25,7 @@ Tudo o que esta skill cria ou edita vive **dentro de `decks/<tema>/`**. Nunca to
 Pergunte de forma objetiva, oferecendo os defaults entre parênteses. Se o usuário já adiantou alguma resposta no pedido, não pergunte de novo.
 
 1. **Nome do tema.** Texto livre. Gere um **slug** em kebab-case, minúsculo, sem acento (ex.: "Spec Driven Development" → `spec-driven-development`). Confirme o slug com o usuário se houver ambiguidade.
-2. **Template do deck** (esqueleto). Liste **dinamicamente** as opções varrendo `mira-templates/decks/` (cada subpasta com `index.html` é um template). Os built-in são `aula-capitulo` (default), `pitch-projeto` e `demo-tecnica`; templates criados pelo `/mira-image-template` aparecem aqui automaticamente, junto com os existentes. Mostre todos e deixe o usuário escolher.
+2. **Template do deck** (esqueleto). Liste **dinamicamente** as opções varrendo `mira-templates/decks/` (cada subpasta com `index.html` é um template). Os built-in são `aula-capitulo` (default), `pitch-projeto`, `demo-tecnica` e `animacao-livre`; templates criados pelo `/mira-image-template` aparecem aqui automaticamente, junto com os existentes. Mostre todos e deixe o usuário escolher.
 3. **Tema base** (identidade visual). Liste **dinamicamente** varrendo `mira-templates/themes/` (cada `.css`, exceto `base.css`, é um tema). Os built-in são `mira-dark` (default, laranja), `light-minimal`, `corporate-blue` e `neon-emerald`; temas gerados pelo `/mira-image-template` aparecem aqui também. **Se o template escolhido tiver um tema de mesmo nome** (caso dos templates derivados de imagem), use-o como **padrão** desse template, pois é a identidade que veio da imagem; o usuário ainda pode escolher outro.
 4. **Cor principal** (opcional). Se o usuário não pedir, use a cor do tema base. Se pedir uma cor (hex `#RRGGBB` ou nome como "roxo"), converta para hex e trate como override no Passo 3. Confirme a cor escolhida.
 5. **Descrição do tema.** Uma ou duas frases: do que trata, para quem, qual o objetivo. Isso vira a semente do briefing.
@@ -35,7 +35,7 @@ Se o deck `decks/<slug>/` já existir, avise e pergunte se é para usar outro no
 
 ### Passo 2: Montar o deck
 
-Para os **templates built-in** (`aula-capitulo`, `pitch-projeto`, `demo-tecnica`) com um **tema built-in**, use o comando canônico do Mira, que copia o esqueleto, injeta o CSS do tema e registra no config:
+Para os **templates built-in** (`aula-capitulo`, `pitch-projeto`, `demo-tecnica`, `animacao-livre`) com um **tema built-in**, use o comando canônico do Mira, que copia o esqueleto, injeta o CSS do tema e registra no config:
 
 ```bash
 npx mira-animator new <slug> --deck=<template> --theme=<tema-base>
@@ -43,7 +43,7 @@ npx mira-animator new <slug> --deck=<template> --theme=<tema-base>
 
 Isso cria `decks/<slug>/index.html` com o tema base já embutido (entre os marcadores `/* @MIRA:THEME:START */` e `/* @MIRA:THEME:END */`).
 
-> **Para templates ou temas criados pelo `/mira-image-template`** (e como fallback sem npx em qualquer caso): monte na mão a partir da cópia local. Copie `mira-templates/decks/<template>/index.html` para `decks/<slug>/index.html`, substitua o bloco entre os marcadores `@MIRA:THEME` pelo CSS de `mira-templates/themes/<tema>.css` seguido de `mira-templates/themes/base.css`, e adicione o deck em `mira.config.json` (`decks[]`). O CLI só conhece os três decks e quatro temas built-in, então templates/temas derivados de imagem **precisam** desta montagem local.
+> **Para templates ou temas criados pelo `/mira-image-template`** (e como fallback sem npx em qualquer caso): monte na mão a partir da cópia local. Copie `mira-templates/decks/<template>/index.html` para `decks/<slug>/index.html`, substitua o bloco entre os marcadores `@MIRA:THEME` pelo CSS de `mira-templates/themes/<tema>.css` seguido de `mira-templates/themes/base.css`, e adicione o deck em `mira.config.json` (`decks[]`). O CLI só conhece os decks e temas built-in, então templates/temas derivados de imagem **precisam** desta montagem local.
 
 ### Passo 3: Aplicar a cor principal custom (só se houver override)
 

--- a/bin/mira.js
+++ b/bin/mira.js
@@ -32,7 +32,7 @@ if (!command || command === '--help' || command === '-h') {
                          Opções: --name=<apelido>  --type=projeto|pdf|latex|texto
     sources              Lista as fontes vinculadas
     new <nome>           Cria um novo deck a partir de um template
-                         Opções: --deck=aula-capitulo|pitch-projeto|demo-tecnica|animacao-livre
+                         Opções: --deck=aula-capitulo|pitch-projeto|demo-tecnica|sandeco-just-animation-template
                                  --theme=mira-dark|light-minimal|corporate-blue|neon-emerald
     status               Mostra o estado da instalação e dos decks
     update               Atualiza agents e templates para a última versão

--- a/bin/mira.js
+++ b/bin/mira.js
@@ -32,7 +32,7 @@ if (!command || command === '--help' || command === '-h') {
                          Opções: --name=<apelido>  --type=projeto|pdf|latex|texto
     sources              Lista as fontes vinculadas
     new <nome>           Cria um novo deck a partir de um template
-                         Opções: --deck=aula-capitulo|pitch-projeto|demo-tecnica
+                         Opções: --deck=aula-capitulo|pitch-projeto|demo-tecnica|animacao-livre
                                  --theme=mira-dark|light-minimal|corporate-blue|neon-emerald
     status               Mostra o estado da instalação e dos decks
     update               Atualiza agents e templates para a última versão

--- a/docs/cli.es.md
+++ b/docs/cli.es.md
@@ -65,7 +65,7 @@ Monta `decks/<nombre>/` a partir de una plantilla y registra el deck. Puedes ind
 
 | Elección | Valores |
 |---|---|
-| Plantilla | `aula-capitulo`, `pitch-projeto`, `demo-tecnica`, `animacao-livre` |
+| Plantilla | `aula-capitulo`, `pitch-projeto`, `demo-tecnica`, `sandeco-just-animation-template` |
 | Tema | `mira-dark`, `light-minimal`, `corporate-blue`, `neon-emerald` |
 
 ## `status`

--- a/docs/cli.es.md
+++ b/docs/cli.es.md
@@ -65,7 +65,7 @@ Monta `decks/<nombre>/` a partir de una plantilla y registra el deck. Puedes ind
 
 | Elección | Valores |
 |---|---|
-| Plantilla | `aula-capitulo`, `pitch-projeto`, `demo-tecnica` |
+| Plantilla | `aula-capitulo`, `pitch-projeto`, `demo-tecnica`, `animacao-livre` |
 | Tema | `mira-dark`, `light-minimal`, `corporate-blue`, `neon-emerald` |
 
 ## `status`

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -65,7 +65,7 @@ It assembles `decks/<name>/` from a template and registers it. You can spell out
 
 | Choice | Values |
 |---|---|
-| Template | `aula-capitulo`, `pitch-projeto`, `demo-tecnica` |
+| Template | `aula-capitulo`, `pitch-projeto`, `demo-tecnica`, `animacao-livre` |
 | Theme | `mira-dark`, `light-minimal`, `corporate-blue`, `neon-emerald` |
 
 ## `status`

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -65,7 +65,7 @@ It assembles `decks/<name>/` from a template and registers it. You can spell out
 
 | Choice | Values |
 |---|---|
-| Template | `aula-capitulo`, `pitch-projeto`, `demo-tecnica`, `animacao-livre` |
+| Template | `aula-capitulo`, `pitch-projeto`, `demo-tecnica`, `sandeco-just-animation-template` |
 | Theme | `mira-dark`, `light-minimal`, `corporate-blue`, `neon-emerald` |
 
 ## `status`

--- a/docs/cli.pt.md
+++ b/docs/cli.pt.md
@@ -65,7 +65,7 @@ Ela monta `decks/<nome>/` a partir de um template e registra o deck. Você pode 
 
 | Escolha | Valores |
 |---|---|
-| Template | `aula-capitulo`, `pitch-projeto`, `demo-tecnica`, `animacao-livre` |
+| Template | `aula-capitulo`, `pitch-projeto`, `demo-tecnica`, `sandeco-just-animation-template` |
 | Tema | `mira-dark`, `light-minimal`, `corporate-blue`, `neon-emerald` |
 
 ## `status`

--- a/docs/cli.pt.md
+++ b/docs/cli.pt.md
@@ -65,7 +65,7 @@ Ela monta `decks/<nome>/` a partir de um template e registra o deck. Você pode 
 
 | Escolha | Valores |
 |---|---|
-| Template | `aula-capitulo`, `pitch-projeto`, `demo-tecnica` |
+| Template | `aula-capitulo`, `pitch-projeto`, `demo-tecnica`, `animacao-livre` |
 | Tema | `mira-dark`, `light-minimal`, `corporate-blue`, `neon-emerald` |
 
 ## `status`

--- a/docs/temas.es.md
+++ b/docs/temas.es.md
@@ -39,6 +39,7 @@ La capa `decks/` guarda presentaciones completas y ejecutables que sirven de **e
 | `aula-capitulo` | Una clase o conferencia a partir de un capítulo / módulo. |
 | `pitch-projeto` | Un pitch de proyecto. |
 | `demo-tecnica` | Una demo técnica o walkthrough. |
+| `animacao-livre` | Un escenario #000000, sin texto, solo para animacion libre. |
 
 ## Los marcadores `@MIRA:`
 

--- a/docs/temas.es.md
+++ b/docs/temas.es.md
@@ -39,7 +39,7 @@ La capa `decks/` guarda presentaciones completas y ejecutables que sirven de **e
 | `aula-capitulo` | Una clase o conferencia a partir de un capítulo / módulo. |
 | `pitch-projeto` | Un pitch de proyecto. |
 | `demo-tecnica` | Una demo técnica o walkthrough. |
-| `animacao-livre` | Un escenario #000000, sin texto, solo para animacion libre. |
+| `sandeco-just-animation-template` | Un escenario #000000, sin texto, solo para animacion libre. |
 
 ## Los marcadores `@MIRA:`
 

--- a/docs/temas.md
+++ b/docs/temas.md
@@ -39,7 +39,7 @@ The `decks/` layer holds complete, runnable presentations that serve as **skelet
 | `aula-capitulo` | A class or lecture built from a chapter / module. |
 | `pitch-projeto` | A project pitch. |
 | `demo-tecnica` | A technical demo or walkthrough. |
-| `animacao-livre` | A #000000 stage with no text, only free-form animation. |
+| `sandeco-just-animation-template` | A #000000 stage with no text, only free-form animation. |
 
 ## The `@MIRA:` markers
 

--- a/docs/temas.md
+++ b/docs/temas.md
@@ -39,6 +39,7 @@ The `decks/` layer holds complete, runnable presentations that serve as **skelet
 | `aula-capitulo` | A class or lecture built from a chapter / module. |
 | `pitch-projeto` | A project pitch. |
 | `demo-tecnica` | A technical demo or walkthrough. |
+| `animacao-livre` | A #000000 stage with no text, only free-form animation. |
 
 ## The `@MIRA:` markers
 

--- a/docs/temas.pt.md
+++ b/docs/temas.pt.md
@@ -39,7 +39,7 @@ A camada `decks/` guarda apresentações completas e rodáveis que servem de **e
 | `aula-capitulo` | Uma aula ou palestra a partir de um capítulo / módulo. |
 | `pitch-projeto` | Um pitch de projeto. |
 | `demo-tecnica` | Uma demo técnica ou walkthrough. |
-| `animacao-livre` | Um palco em #000000, sem texto, apenas para animacao livre. |
+| `sandeco-just-animation-template` | Um palco em #000000, sem texto, apenas para animacao livre. |
 
 ## Os marcadores `@MIRA:`
 

--- a/docs/temas.pt.md
+++ b/docs/temas.pt.md
@@ -39,6 +39,7 @@ A camada `decks/` guarda apresentações completas e rodáveis que servem de **e
 | `aula-capitulo` | Uma aula ou palestra a partir de um capítulo / módulo. |
 | `pitch-projeto` | Um pitch de projeto. |
 | `demo-tecnica` | Uma demo técnica ou walkthrough. |
+| `animacao-livre` | Um palco em #000000, sem texto, apenas para animacao livre. |
 
 ## Os marcadores `@MIRA:`
 

--- a/docs/uso.es.md
+++ b/docs/uso.es.md
@@ -33,7 +33,7 @@ Pregunta el nombre del tema, la plantilla del deck, el tema base, el color princ
 | `aula-capitulo` | Una clase o conferencia a partir de un capítulo / módulo |
 | `pitch-projeto` | Un pitch de proyecto |
 | `demo-tecnica` | Una demo técnica / walkthrough |
-| `animacao-livre` | Un escenario negro, sin texto, solo para la animacion de Mira |
+| `sandeco-just-animation-template` | Un escenario negro, sin texto, solo para la animacion de Mira |
 
 **Temas:** `mira-dark`, `light-minimal`, `corporate-blue`, `neon-emerald`.
 

--- a/docs/uso.es.md
+++ b/docs/uso.es.md
@@ -33,6 +33,7 @@ Pregunta el nombre del tema, la plantilla del deck, el tema base, el color princ
 | `aula-capitulo` | Una clase o conferencia a partir de un capítulo / módulo |
 | `pitch-projeto` | Un pitch de proyecto |
 | `demo-tecnica` | Una demo técnica / walkthrough |
+| `animacao-livre` | Un escenario negro, sin texto, solo para la animacion de Mira |
 
 **Temas:** `mira-dark`, `light-minimal`, `corporate-blue`, `neon-emerald`.
 

--- a/docs/uso.md
+++ b/docs/uso.md
@@ -33,7 +33,7 @@ It asks for the theme name, the deck template, the base theme, the primary color
 | `aula-capitulo` | A class or lecture from a chapter / module |
 | `pitch-projeto` | A project pitch |
 | `demo-tecnica` | A technical demo / walkthrough |
-| `animacao-livre` | A black stage with no text, only the Mira animation |
+| `sandeco-just-animation-template` | A black stage with no text, only the Mira animation |
 
 **Themes:** `mira-dark`, `light-minimal`, `corporate-blue`, `neon-emerald`.
 

--- a/docs/uso.md
+++ b/docs/uso.md
@@ -33,6 +33,7 @@ It asks for the theme name, the deck template, the base theme, the primary color
 | `aula-capitulo` | A class or lecture from a chapter / module |
 | `pitch-projeto` | A project pitch |
 | `demo-tecnica` | A technical demo / walkthrough |
+| `animacao-livre` | A black stage with no text, only the Mira animation |
 
 **Themes:** `mira-dark`, `light-minimal`, `corporate-blue`, `neon-emerald`.
 

--- a/docs/uso.pt.md
+++ b/docs/uso.pt.md
@@ -33,6 +33,7 @@ Ela pergunta o nome do tema, o template do deck, o tema base, a cor principal e 
 | `aula-capitulo` | Uma aula ou palestra a partir de um capítulo / módulo |
 | `pitch-projeto` | Um pitch de projeto |
 | `demo-tecnica` | Uma demo técnica / walkthrough |
+| `animacao-livre` | Um palco preto, sem texto, apenas para a animacao do Mira |
 
 **Temas:** `mira-dark`, `light-minimal`, `corporate-blue`, `neon-emerald`.
 

--- a/docs/uso.pt.md
+++ b/docs/uso.pt.md
@@ -33,7 +33,7 @@ Ela pergunta o nome do tema, o template do deck, o tema base, a cor principal e 
 | `aula-capitulo` | Uma aula ou palestra a partir de um capítulo / módulo |
 | `pitch-projeto` | Um pitch de projeto |
 | `demo-tecnica` | Uma demo técnica / walkthrough |
-| `animacao-livre` | Um palco preto, sem texto, apenas para a animacao do Mira |
+| `sandeco-just-animation-template` | Um palco preto, sem texto, apenas para a animacao do Mira |
 
 **Temas:** `mira-dark`, `light-minimal`, `corporate-blue`, `neon-emerald`.
 

--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -2,7 +2,7 @@ import { join } from 'path';
 import { existsSync, mkdirSync, cpSync, readFileSync, writeFileSync } from 'fs';
 import { MIRA_ROOT, PROJECT_ROOT, loadConfig, saveConfig } from '../utils/paths.js';
 
-const DECKS = ['aula-capitulo', 'pitch-projeto', 'demo-tecnica', 'animacao-livre'];
+const DECKS = ['aula-capitulo', 'pitch-projeto', 'demo-tecnica', 'sandeco-just-animation-template'];
 const THEMES = ['mira-dark', 'light-minimal', 'corporate-blue', 'neon-emerald'];
 
 export default async function newDeck(args) {

--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -2,7 +2,7 @@ import { join } from 'path';
 import { existsSync, mkdirSync, cpSync, readFileSync, writeFileSync } from 'fs';
 import { MIRA_ROOT, PROJECT_ROOT, loadConfig, saveConfig } from '../utils/paths.js';
 
-const DECKS = ['aula-capitulo', 'pitch-projeto', 'demo-tecnica'];
+const DECKS = ['aula-capitulo', 'pitch-projeto', 'demo-tecnica', 'animacao-livre'];
 const THEMES = ['mira-dark', 'light-minimal', 'corporate-blue', 'neon-emerald'];
 
 export default async function newDeck(args) {

--- a/templates/decks/animacao-livre/index.html
+++ b/templates/decks/animacao-livre/index.html
@@ -1,0 +1,194 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Mira - Template: Animacao Livre</title>
+    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <style>
+        /* @MIRA:THEME:START */
+:root {
+    --mira-primary: #ffffff;
+    --mira-bg: #000000;
+    --mira-text: #ffffff;
+    --mira-text-soft: rgba(255, 255, 255, 0.72);
+    --mira-text-softer: rgba(255, 255, 255, 0.50);
+    --mira-card-bg: transparent;
+    --mira-card-border: transparent;
+    --mira-glow-soft: rgba(255, 255, 255, 0.12);
+    --mira-glow-strong: rgba(255, 255, 255, 0.22);
+    --mira-icon-bg: transparent;
+    --mira-icon-border: transparent;
+    --mira-pill-bg: transparent;
+    --mira-pill-border: transparent;
+    --mira-stage-glow: transparent;
+    --mira-accent-2: #d7e3ff;
+}
+
+body {
+    background: var(--mira-bg);
+    min-height: 100vh;
+    color: var(--mira-text);
+    font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+        /* @MIRA:THEME:END */
+
+        * {
+            box-sizing: border-box;
+        }
+
+        html,
+        body {
+            width: 100%;
+            min-height: 100%;
+            margin: 0;
+            overflow: hidden;
+            background: #000000;
+        }
+
+        body {
+            color: #ffffff;
+        }
+
+        .mira-animation-only {
+            position: fixed;
+            inset: 0;
+            width: 100vw;
+            height: 100vh;
+            overflow: hidden;
+            background: #000000;
+        }
+
+        .mira-animation-only svg {
+            display: block;
+            width: 100%;
+            height: 100%;
+        }
+    </style>
+</head>
+
+<body>
+    <!-- @MIRA:SIZE 3/10 -->
+    <!-- Template sem conteudo textual: use apenas animacao sobre fundo #000000. -->
+    <!-- Cores livres, desde que tenham alto contraste com #000000 e nenhuma seja obrigatoria ou predominante. -->
+    <main id="mira-animation-stage" class="mira-animation-only" aria-label="Animacao Mira"></main>
+
+    <script>
+        (function () {
+            const stage = document.getElementById('mira-animation-stage');
+            const palette = [
+                '#ffffff',
+                '#00E5FF',
+                '#7CFF6B',
+                '#FFD166',
+                '#FF5C8A',
+                '#B388FF'
+            ];
+
+            const svg = d3.select(stage)
+                .append('svg')
+                .attr('role', 'img')
+                .attr('preserveAspectRatio', 'xMidYMid slice');
+
+            const root = svg.append('g');
+            const background = root.append('rect').attr('fill', '#000000');
+            const aura = root.append('g').attr('opacity', 0.62);
+            const field = root.append('g');
+            const lattice = root.append('g').attr('opacity', 0.42);
+
+            let width = 0;
+            let height = 0;
+            let nodes = [];
+            let links = [];
+
+            function buildScene() {
+                width = window.innerWidth;
+                height = window.innerHeight;
+                svg.attr('viewBox', `0 0 ${width} ${height}`);
+                background.attr('width', width).attr('height', height);
+
+                const diagonal = Math.hypot(width, height);
+                const count = Math.max(42, Math.round((width * height) / 24500));
+                nodes = d3.range(count).map((_, index) => {
+                    const angle = (index / count) * Math.PI * 2;
+                    const radius = diagonal * (0.08 + Math.random() * 0.34);
+                    return {
+                        x: width / 2 + Math.cos(angle) * radius * (0.58 + Math.random() * 0.5),
+                        y: height / 2 + Math.sin(angle) * radius * (0.46 + Math.random() * 0.42),
+                        baseX: width / 2 + Math.cos(angle) * radius,
+                        baseY: height / 2 + Math.sin(angle) * radius * 0.58,
+                        radius: 2.2 + Math.random() * 4.8,
+                        orbit: 18 + Math.random() * 84,
+                        speed: 0.00055 + Math.random() * 0.0018,
+                        phase: Math.random() * Math.PI * 2,
+                        color: palette[index % palette.length]
+                    };
+                });
+
+                links = d3.range(count).map(i => ({
+                    source: nodes[i],
+                    target: nodes[(i + 5) % count],
+                    color: palette[(i + 2) % palette.length]
+                }));
+
+                aura.selectAll('circle')
+                    .data(palette)
+                    .join('circle')
+                    .attr('cx', (d, i) => width / 2 + Math.cos((i / palette.length) * Math.PI * 2) * width * 0.16)
+                    .attr('cy', (d, i) => height / 2 + Math.sin((i / palette.length) * Math.PI * 2) * height * 0.11)
+                    .attr('r', Math.min(width, height) * 0.18)
+                    .attr('fill', d => d)
+                    .attr('opacity', 0.11)
+                    .style('filter', 'blur(38px)');
+
+                lattice.selectAll('line')
+                    .data(links)
+                    .join('line')
+                    .attr('stroke', d => d.color)
+                    .attr('stroke-width', 1)
+                    .attr('stroke-opacity', 0.32);
+
+                field.selectAll('circle')
+                    .data(nodes)
+                    .join('circle')
+                    .attr('r', d => d.radius)
+                    .attr('fill', d => d.color)
+                    .attr('fill-opacity', 0.9)
+                    .style('filter', d => `drop-shadow(0 0 10px ${d.color})`);
+            }
+
+            buildScene();
+            window.addEventListener('resize', buildScene);
+
+            d3.timer(elapsed => {
+                aura.selectAll('circle')
+                    .attr('transform', (d, i) => {
+                        const a = elapsed * 0.00018 + i;
+                        return `translate(${Math.cos(a) * 28},${Math.sin(a * 1.3) * 22})`;
+                    });
+
+                nodes.forEach((node, index) => {
+                    const angle = node.phase + elapsed * node.speed;
+                    const drift = Math.sin(elapsed * 0.00045 + index) * 18;
+                    node.x = node.baseX + Math.cos(angle) * node.orbit + drift;
+                    node.y = node.baseY + Math.sin(angle * 1.4) * node.orbit * 0.72;
+                });
+
+                lattice.selectAll('line')
+                    .attr('x1', d => d.source.x)
+                    .attr('y1', d => d.source.y)
+                    .attr('x2', d => d.target.x)
+                    .attr('y2', d => d.target.y)
+                    .attr('stroke-opacity', (_, i) => 0.16 + Math.sin(elapsed * 0.001 + i) * 0.12);
+
+                field.selectAll('circle')
+                    .attr('cx', d => d.x)
+                    .attr('cy', d => d.y)
+                    .attr('r', (d, i) => d.radius * (1 + Math.sin(elapsed * 0.003 + i) * 0.24));
+            });
+        })();
+    </script>
+</body>
+
+</html>

--- a/templates/decks/sandeco-just-animation-template/index.html
+++ b/templates/decks/sandeco-just-animation-template/index.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Mira - Template: Animacao Livre</title>
+    <title>Mira - Template: Sandeco Just Animation Template</title>
     <script src="https://d3js.org/d3.v7.min.js"></script>
     <style>
         /* @MIRA:THEME:START */


### PR DESCRIPTION
Fechado porque as mudanças foram aplicadas diretamente em `main` por cherry-pick sobre o `origin/main` atualizado, junto com o bump de release para `0.1.22`.

Commits em `main`:
- `f873aad` feat(templates): adiciona animacao livre
- `c8979ee` chore(templates): renomeia template de animacao
- `fc0c901` chore(release): prepara 0.1.22

Validação antes do push:
- `node --check lib/commands/new.js`
- `node --check bin/mira.js`
- Smoke test com `--deck=sandeco-just-animation-template --theme=light-minimal`
- `node --check` no script embutido extraído do HTML gerado
- `npm pack --dry-run` com pacote `mira-animator@0.1.22`