### PR TITLE
feat: add optional global installation cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,5 @@ mira.config.json
 
 # Registro de geracao do /mira-fast: fica no disco para inspecao, fora do repo
 decks/**/mira/fast/
+
+tasks/*.diff

--- a/agents/mira-fast/scripts/assemble-run.mjs
+++ b/agents/mira-fast/scripts/assemble-run.mjs
@@ -346,14 +346,33 @@ function publishOutput(outputPath, content) {
     }
   }
 
-  rmSync(backupPath, { force: true });
-  renameSync(outputPath, backupPath);
+  let backupCreated = false;
+  let outputPublished = false;
   try {
+    renameSync(outputPath, backupPath);
+    backupCreated = true;
     renameSync(tempPath, outputPath);
+    outputPublished = true;
     rmSync(backupPath, { force: true });
   } catch (error) {
-    if (existsSync(backupPath) && !existsSync(outputPath)) renameSync(backupPath, outputPath);
-    rmSync(tempPath, { force: true });
+    const rollbackErrors = [];
+    try {
+      if (outputPublished) rmSync(outputPath, { recursive: true, force: true });
+      if (backupCreated) renameSync(backupPath, outputPath);
+    } catch (rollbackError) {
+      rollbackErrors.push(rollbackError);
+    }
+    try {
+      rmSync(tempPath, { force: true });
+    } catch (cleanupError) {
+      rollbackErrors.push(cleanupError);
+    }
+    if (rollbackErrors.length) {
+      throw new AggregateError(
+        [error, ...rollbackErrors],
+        `publicação falhou: ${error.message}; rollback falhou: ${rollbackErrors.map((rollbackError) => rollbackError.message).join(' | ')}`,
+      );
+    }
     throw error;
   }
 }

--- a/bin/mira.js
+++ b/bin/mira.js
@@ -20,6 +20,7 @@ const commands = {
   plugin:    () => import('../lib/commands/plugin.js'),
   status:    () => import('../lib/commands/status.js'),
   update:    () => import('../lib/commands/update.js'),
+  global:    () => import('../lib/commands/global.js'),
   uninstall: () => import('../lib/commands/uninstall.js'),
 };
 
@@ -49,6 +50,7 @@ if (!command || command === '--help' || command === '-h') {
                          Instalar é colocar a pasta; desinstalar é apagar
     status               Mostra o estado da instalação e dos decks
     update               Atualiza agents e templates para a última versão
+    global <sub>         Mantém o cache global opcional (install | update | status)
     uninstall            Remove o Mira da pasta atual
 
   Documentação: https://github.com/sandeco/mira-animator

--- a/lib/commands/global.js
+++ b/lib/commands/global.js
@@ -1,0 +1,28 @@
+import { globalStatus, installGlobal } from '../global/installation.js';
+
+export default async function global(args = []) {
+  const [operation] = args;
+  if (!['install', 'update', 'status'].includes(operation)) {
+    console.error('\n  Uso: mira global <install|update|status>\n');
+    process.exitCode = 1;
+    return;
+  }
+
+  if (operation === 'status') {
+    const status = globalStatus();
+    if (!status.exists) {
+      console.log('\n  Instalação global do Mira não encontrada.\n');
+      return;
+    }
+    console.log(`\n  Instalação global: ${status.path}`);
+    console.log(`  Versão instalada: ${status.installedVersion}`);
+    console.log(`  Versão em execução: ${status.packageVersion}`);
+    console.log(`  Integridade: ${status.corrupted ? 'CORROMPIDA' : 'válida'} (agents: ${status.agents ? 'ok' : 'ausente'}, templates: ${status.templates ? 'ok' : 'ausente'})\n`);
+    if (status.corrupted) process.exitCode = 1;
+    return;
+  }
+
+  const result = installGlobal({ operation });
+  console.log(`\n  Mira global ${operation === 'install' ? 'instalado' : 'atualizado'} em: ${result.path}`);
+  console.log(`  Versão: ${result.version}\n`);
+}

--- a/lib/global/installation.js
+++ b/lib/global/installation.js
@@ -1,0 +1,170 @@
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { MIRA_ROOT } from '../utils/paths.js';
+import { resolveGlobalPaths } from './paths.js';
+
+const DEFAULT_FILE_SYSTEM = Object.freeze({
+  exists: existsSync,
+  rename: renameSync,
+  remove: rmSync,
+});
+
+function packageVersion() {
+  return JSON.parse(readFileSync(join(MIRA_ROOT, 'package.json'), 'utf8')).version;
+}
+
+function readInstallation(current) {
+  const path = join(current, 'installation.json');
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function collectError(errors, operation) {
+  try {
+    operation();
+  } catch (error) {
+    errors.push(error);
+  }
+}
+
+function throwRecoveryError(error, recoveryErrors, phase) {
+  if (recoveryErrors.length) {
+    throw new AggregateError(
+      [error, ...recoveryErrors],
+      `${phase} falhou: ${error.message}; recuperação falhou: ${recoveryErrors.map((item) => item.message).join(' | ')}`,
+    );
+  }
+  throw error;
+}
+
+function cleanupStaging(staging, stateStaging, fileSystem, error) {
+  const cleanupErrors = [];
+  collectError(cleanupErrors, () => {
+    if (fileSystem.exists(staging)) fileSystem.remove(staging, { recursive: true, force: true });
+  });
+  collectError(cleanupErrors, () => {
+    if (fileSystem.exists(stateStaging)) fileSystem.remove(stateStaging, { force: true });
+  });
+  throwRecoveryError(error, cleanupErrors, 'preparo da instalação global');
+}
+
+function publishGlobal(paths, staging, stateStaging, fileSystem) {
+  const backup = `${paths.current}.backup-${process.pid}-${Date.now()}`;
+  const stateBackup = `${paths.state}.backup-${process.pid}-${Date.now()}`;
+  let backupCreated = false;
+  let published = false;
+  let stateBackupCreated = false;
+  let statePublished = false;
+  try {
+    if (existsSync(paths.current)) {
+      fileSystem.rename(paths.current, backup);
+      backupCreated = true;
+    }
+    fileSystem.rename(staging, paths.current);
+    published = true;
+    if (existsSync(paths.state)) {
+      fileSystem.rename(paths.state, stateBackup);
+      stateBackupCreated = true;
+    }
+    fileSystem.rename(stateStaging, paths.state);
+    statePublished = true;
+  } catch (error) {
+    const rollbackErrors = [];
+    collectError(rollbackErrors, () => {
+      if (statePublished && fileSystem.exists(paths.state)) fileSystem.remove(paths.state, { force: true });
+    });
+    collectError(rollbackErrors, () => {
+      if (stateBackupCreated && fileSystem.exists(stateBackup)) fileSystem.rename(stateBackup, paths.state);
+    });
+    collectError(rollbackErrors, () => {
+      if (published && fileSystem.exists(paths.current)) fileSystem.remove(paths.current, { recursive: true, force: true });
+    });
+    collectError(rollbackErrors, () => {
+      if (backupCreated && fileSystem.exists(backup)) fileSystem.rename(backup, paths.current);
+    });
+    collectError(rollbackErrors, () => {
+      if (fileSystem.exists(staging)) fileSystem.remove(staging, { recursive: true, force: true });
+    });
+    collectError(rollbackErrors, () => {
+      if (fileSystem.exists(stateStaging)) fileSystem.remove(stateStaging, { force: true });
+    });
+    throwRecoveryError(error, rollbackErrors, 'publicação global');
+  }
+
+  const cleanupErrors = [];
+  collectError(cleanupErrors, () => {
+    if (backupCreated && fileSystem.exists(backup)) fileSystem.remove(backup, { recursive: true, force: true });
+  });
+  collectError(cleanupErrors, () => {
+    if (stateBackupCreated && fileSystem.exists(stateBackup)) fileSystem.remove(stateBackup, { force: true });
+  });
+  if (cleanupErrors.length) {
+    throw new AggregateError(
+      cleanupErrors,
+      `publicação global concluída, mas a limpeza de backup falhou: ${cleanupErrors.map((item) => item.message).join(' | ')}`,
+    );
+  }
+}
+
+export function installGlobal({ paths = resolveGlobalPaths(), operation = 'install', copyDirectory = cpSync, fileSystem = DEFAULT_FILE_SYSTEM } = {}) {
+  const version = packageVersion();
+  const now = new Date().toISOString();
+  const prior = readInstallation(paths.current);
+  const staging = `${paths.current}.staging-${process.pid}-${Date.now()}`;
+  const stateStaging = `${paths.state}.staging-${process.pid}-${Date.now()}`;
+  mkdirSync(paths.root, { recursive: true });
+
+  try {
+    copyDirectory(join(MIRA_ROOT, 'agents'), join(staging, 'agents'), { recursive: true, force: true });
+    copyDirectory(join(MIRA_ROOT, 'templates'), join(staging, 'templates'), { recursive: true, force: true });
+    writeFileSync(join(staging, 'installation.json'), JSON.stringify({
+      version,
+      installedAt: prior?.installedAt ?? now,
+      updatedAt: now,
+    }, null, 2) + '\n', 'utf8');
+    writeFileSync(stateStaging, JSON.stringify({ version, updatedAt: now }, null, 2) + '\n', 'utf8');
+  } catch (error) {
+    cleanupStaging(staging, stateStaging, fileSystem, error);
+  }
+
+  publishGlobal(paths, staging, stateStaging, fileSystem);
+  return { path: paths.current, version, operation };
+}
+
+export function globalStatus({ paths = resolveGlobalPaths() } = {}) {
+  if (!existsSync(paths.current) && !existsSync(paths.state)) {
+    return { exists: false, corrupted: false };
+  }
+
+  const installation = readInstallation(paths.current);
+  const agents = existsSync(join(paths.current, 'agents'));
+  const templates = existsSync(join(paths.current, 'templates'));
+  let state = null;
+  try {
+    state = JSON.parse(readFileSync(paths.state, 'utf8'));
+  } catch {
+    // Estado ausente ou inválido também torna a instalação incompleta.
+  }
+  const corrupted = !installation || !state || !agents || !templates;
+  return {
+    exists: true,
+    corrupted,
+    path: paths.current,
+    installedVersion: installation?.version ?? '?',
+    packageVersion: packageVersion(),
+    agents,
+    templates,
+  };
+}

--- a/lib/global/paths.js
+++ b/lib/global/paths.js
@@ -1,0 +1,11 @@
+import { homedir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+export function resolveGlobalPaths({ homeDir = homedir() } = {}) {
+  const root = join(resolve(homeDir), '.mira');
+  return {
+    root,
+    current: join(root, 'current'),
+    state: join(root, 'state.json'),
+  };
+}

--- a/tasks/task-001.md
+++ b/tasks/task-001.md
@@ -1,0 +1,112 @@
+Você tem razão. Eu mandei uma referência vaga para um plano que não estava no prompt atual.
+
+Envie **este prompt completo** ao Codex:
+
+```text
+Implemente o primeiro slice de uma instalação global opcional para o Mira Animator.
+
+Contexto:
+- o comportamento local atual deve permanecer totalmente compatível;
+- install e update sem flags continuam operando na pasta atual;
+- este slice cria apenas o cache global;
+- ainda não conecte workspaces ao cache;
+- ainda não crie symlinks, junctions ou registro de workspaces;
+- não implemente update --all;
+- não altere decks existentes.
+
+Objetivo:
+Adicionar os comandos:
+
+npx mira-animator global install
+npx mira-animator global update
+npx mira-animator global status
+
+Diretório global:
+- usar o diretório home do usuário;
+- criar ~/.mira;
+- resolver o home com APIs multiplataforma do Node;
+- não concatenar USERPROFILE manualmente.
+
+Estrutura esperada:
+
+~/.mira/
+├── current/
+│   ├── agents/
+│   ├── templates/
+│   └── installation.json
+└── state.json
+
+Contrato do comando global install:
+- criar ~/.mira/current;
+- copiar agents e templates distribuídos pelo pacote;
+- gravar metadados da instalação;
+- ser idempotente;
+- não escrever na pasta atual;
+- não criar mira.config.json local;
+- não criar decks;
+- não modificar .claude.
+
+Contrato do comando global update:
+- atualizar agents e templates;
+- usar publicação atômica;
+- preservar a instalação anterior se a atualização falhar;
+- não modificar workspaces locais.
+
+Contrato do comando global status:
+- informar se a instalação global existe;
+- mostrar caminho absoluto;
+- mostrar versão instalada;
+- mostrar versão do pacote em execução;
+- verificar integridade básica de agents e templates;
+- retornar exit code diferente de zero somente se a instalação estiver corrompida;
+- instalação ausente não deve ser tratada como corrupção.
+
+Arquitetura:
+- criar módulo isolado para resolução dos caminhos globais;
+- criar módulo isolado para instalação e publicação do cache;
+- reutilizar lógica de cópia existente quando for seguro;
+- usar apenas APIs Node para arquivos e caminhos;
+- tratar caminhos com espaços;
+- não depender de instalação npm global.
+
+Compatibilidade obrigatória:
+- não alterar o comportamento de:
+  - mira-animator install
+  - mira-animator update
+  - mira-animator status
+- não mudar mensagens ou contratos utilizados pelos testes existentes.
+
+Testes obrigatórios:
+- resolução do caminho global;
+- instalação global em diretório temporário;
+- idempotência;
+- atualização;
+- rollback em falha;
+- status ausente;
+- status válido;
+- status corrompido;
+- garantia de que nenhum arquivo é criado no cwd;
+- suíte completa existente.
+
+Testabilidade:
+- permitir substituir o diretório global nos testes;
+- nunca usar o home real nos testes;
+- não deixar arquivos fora do diretório temporário.
+
+Não implementar neste slice:
+- symlinks;
+- junctions;
+- use-global;
+- workspaces.json;
+- update --all;
+- migração de instalações locais;
+- alterações extensas de documentação.
+
+Ao finalizar:
+1. explique a arquitetura adotada;
+2. liste arquivos criados e alterados;
+3. mostre os testes adicionados;
+4. execute npm test;
+5. execute git diff --check;
+6. não faça commit.
+```

--- a/tasks/task-002.md
+++ b/tasks/task-002.md
@@ -1,0 +1,64 @@
+# Task 002 — Harden global cache transaction rollback
+
+Review and correct the implementation from `tasks/task-001.md`. Do not commit.
+
+## Blocking issue
+
+`publishGlobal()` currently groups all rollback operations inside a single `try`. If restoring `state.json` fails, restoration of `current/` is skipped. Rollback must attempt every independent recovery step and aggregate all failures.
+
+There is also a commit/cleanup hazard: after both new paths are published, one backup may be deleted successfully and deletion of the other may fail. The current catch path can then try to roll back using a backup that no longer exists, risking loss of the previous installation.
+
+## Required changes
+
+1. Separate transaction phases clearly:
+   - prepare staging;
+   - move existing destinations to backups;
+   - publish staged `current/`;
+   - publish staged `state.json`;
+   - mark transaction committed;
+   - clean backups as post-commit cleanup.
+
+2. Before commit:
+   - on any failure, attempt every applicable rollback action independently;
+   - do not stop rollback because one action failed;
+   - collect all rollback and cleanup errors;
+   - restore both `current/` and `state.json` whenever their backups exist;
+   - preserve the original failure together with all recovery failures using `AggregateError`.
+
+3. After commit:
+   - backup cleanup failure must not trigger rollback using backups already removed;
+   - never delete the newly committed installation because post-commit cleanup failed;
+   - report cleanup failure diagnostically while preserving the valid committed state, or retain leftover backup safely for later cleanup.
+
+4. Apply the same independent-cleanup discipline to failures during staging preparation.
+
+5. Do not change the existing local `install`, `update`, or `status` behavior.
+
+## Tests to add
+
+Add regression tests proving that:
+
+1. failure restoring `state.json` does not prevent an attempted restoration of `current/`;
+2. failure restoring `current/` does not prevent cleanup/restoration attempts for `state.json`;
+3. failure deleting one backup after commit does not remove or corrupt the newly committed global installation;
+4. all relevant errors are visible in the resulting `AggregateError`;
+5. no staging paths remain after successful rollback when cleanup operations themselves do not fail.
+
+Use injected filesystem operations or a small internal transaction dependency object so failures can be simulated deterministically. Do not mutate the real user home.
+
+## Validation
+
+Run:
+
+- `node --test test/global-installation.test.mjs`
+- `npm test`
+- `git diff --check`
+
+At the end, provide:
+- cause and design of the correction;
+- files changed;
+- tests added;
+- test results;
+- `git status --short`.
+
+Do not commit.

--- a/test/global-installation.test.mjs
+++ b/test/global-installation.test.mjs
@@ -1,0 +1,254 @@
+import assert from 'node:assert/strict';
+import { existsSync, mkdtempSync, readFileSync, readdirSync, renameSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import test from 'node:test';
+import { resolveGlobalPaths } from '../lib/global/paths.js';
+import { installGlobal, globalStatus } from '../lib/global/installation.js';
+
+const roots = [];
+
+function fixture() {
+  const homeDir = mkdtempSync(join(tmpdir(), 'mira-global-'));
+  roots.push(homeDir);
+  return resolveGlobalPaths({ homeDir });
+}
+
+function fileSystem(overrides = {}) {
+  return {
+    exists: existsSync,
+    rename: renameSync,
+    remove: rmSync,
+    ...overrides,
+  };
+}
+
+function failStatePublication(paths) {
+  return (source, destination) => {
+    if (destination === paths.state && source.startsWith(`${paths.state}.staging-`)) {
+      throw new Error('falha ao publicar state');
+    }
+    return renameSync(source, destination);
+  };
+}
+
+function captureError(operation) {
+  let thrown;
+  try {
+    operation();
+  } catch (error) {
+    thrown = error;
+  }
+  assert.ok(thrown, 'era esperado um erro');
+  return thrown;
+}
+
+test.after(() => {
+  for (const root of roots) rmSync(root, { recursive: true, force: true });
+});
+
+test('global: resolve caminhos a partir do home injetado', () => {
+  const homeDir = resolve('/tmp/casa com espaco');
+  const paths = resolveGlobalPaths({ homeDir });
+  assert.equal(paths.root, join(homeDir, '.mira'));
+  assert.equal(paths.current, join(homeDir, '.mira', 'current'));
+  assert.equal(paths.state, join(homeDir, '.mira', 'state.json'));
+});
+
+test('global: install cria cache sem escrever no cwd', () => {
+  const paths = fixture();
+  const cwd = process.cwd();
+  const outside = mkdtempSync(join(tmpdir(), 'mira-global-cwd-'));
+  roots.push(outside);
+  process.chdir(outside);
+  try {
+    installGlobal({ paths });
+  } finally {
+    process.chdir(cwd);
+  }
+
+  assert.ok(existsSync(join(paths.current, 'agents')));
+  assert.ok(existsSync(join(paths.current, 'templates')));
+  assert.ok(existsSync(join(paths.current, 'installation.json')));
+  assert.ok(existsSync(paths.state));
+  assert.deepEqual(requireDirectoryEntries(outside), []);
+});
+
+test('global: install é idempotente', () => {
+  const paths = fixture();
+  const first = installGlobal({ paths });
+  const second = installGlobal({ paths });
+
+  assert.equal(second.version, first.version);
+  assert.equal(globalStatus({ paths }).corrupted, false);
+});
+
+test('global: update publica uma nova instalação', () => {
+  const paths = fixture();
+  installGlobal({ paths });
+  const result = installGlobal({ paths, operation: 'update' });
+
+  assert.equal(result.operation, 'update');
+  assert.equal(globalStatus({ paths }).exists, true);
+});
+
+test('global: update preserva instalação anterior quando a publicação falha', () => {
+  const paths = fixture();
+  installGlobal({ paths });
+  const installation = join(paths.current, 'installation.json');
+  const before = readFileSync(installation, 'utf8');
+  const stateBefore = readFileSync(paths.state, 'utf8');
+
+  assert.throws(() => installGlobal({
+    paths,
+    operation: 'update',
+    fileSystem: fileSystem({ rename: failStatePublication(paths) }),
+  }), /falha ao publicar state/);
+
+  assert.equal(readFileSync(installation, 'utf8'), before);
+  assert.equal(readFileSync(paths.state, 'utf8'), stateBefore);
+  assert.equal(globalStatus({ paths }).corrupted, false);
+  assert.deepEqual(readdirSync(paths.root).filter((entry) => entry.includes('.staging-')), []);
+});
+
+test('global: falha ao restaurar state não impede tentativa de restaurar current', () => {
+  const paths = fixture();
+  installGlobal({ paths });
+  const calls = [];
+
+  const error = captureError(() => installGlobal({
+    paths,
+    operation: 'update',
+    fileSystem: fileSystem({
+      rename(source, destination) {
+        if (destination === paths.state && source.startsWith(`${paths.state}.staging-`)) {
+          throw new Error('falha ao publicar state');
+        }
+        if (destination === paths.state && source.startsWith(`${paths.state}.backup-`)) {
+          calls.push('restore-state');
+          throw new Error('falha ao restaurar state');
+        }
+        if (destination === paths.current && source.startsWith(`${paths.current}.backup-`)) {
+          calls.push('restore-current');
+        }
+        return renameSync(source, destination);
+      },
+    }),
+  }));
+
+  assert.ok(error instanceof AggregateError);
+  assert.ok(calls.includes('restore-current'));
+  assert.match(error.message, /falha ao publicar state/);
+  assert.match(error.message, /falha ao restaurar state/);
+});
+
+test('global: falha ao restaurar current não impede restauração de state', () => {
+  const paths = fixture();
+  installGlobal({ paths });
+  const stateBefore = readFileSync(paths.state, 'utf8');
+  const calls = [];
+
+  assert.throws(() => installGlobal({
+    paths,
+    operation: 'update',
+    fileSystem: fileSystem({
+      rename(source, destination) {
+        if (destination === paths.state && source.startsWith(`${paths.state}.staging-`)) {
+          throw new Error('falha ao publicar state');
+        }
+        if (destination === paths.current && source.startsWith(`${paths.current}.backup-`)) {
+          calls.push('restore-current');
+          throw new Error('falha ao restaurar current');
+        }
+        if (destination === paths.state && source.startsWith(`${paths.state}.backup-`)) {
+          calls.push('restore-state');
+        }
+        return renameSync(source, destination);
+      },
+    }),
+  }), /falha ao restaurar current/);
+
+  assert.ok(calls.includes('restore-state'));
+  assert.equal(readFileSync(paths.state, 'utf8'), stateBefore);
+});
+
+test('global: AggregateError mantém falha original e todas as falhas de recuperação', () => {
+  const paths = fixture();
+  installGlobal({ paths });
+
+  const error = captureError(() => installGlobal({
+    paths,
+    operation: 'update',
+    fileSystem: fileSystem({
+      rename(source, destination) {
+        if (destination === paths.state && source.startsWith(`${paths.state}.staging-`)) {
+          throw new Error('falha original');
+        }
+        if (source.includes('.backup-') && destination === paths.state) throw new Error('falha restore state');
+        if (source.includes('.backup-') && destination === paths.current) throw new Error('falha restore current');
+        return renameSync(source, destination);
+      },
+    }),
+  }));
+
+  assert.ok(error instanceof AggregateError);
+  assert.deepEqual(error.errors.map((item) => item.message), [
+    'falha original',
+    'falha restore state',
+    'falha restore current',
+  ]);
+});
+
+test('global: limpeza de backup pós-commit não desfaz a instalação publicada', () => {
+  const paths = fixture();
+  installGlobal({ paths });
+  writeFileSync(join(paths.current, 'somente-anterior.txt'), 'antigo', 'utf8');
+  let cleanupFailed = false;
+
+  const error = captureError(() => installGlobal({
+    paths,
+    operation: 'update',
+    fileSystem: fileSystem({
+      remove(path, options) {
+        if (!cleanupFailed && path.startsWith(`${paths.current}.backup-`)) {
+          cleanupFailed = true;
+          throw new Error('falha ao limpar backup current');
+        }
+        return rmSync(path, options);
+      },
+    }),
+  }));
+
+  assert.ok(error instanceof AggregateError);
+  assert.equal(existsSync(join(paths.current, 'somente-anterior.txt')), false);
+  assert.equal(globalStatus({ paths }).corrupted, false);
+});
+
+test('global: status ausente não é corrupção', () => {
+  const status = globalStatus({ paths: fixture() });
+  assert.deepEqual(status, { exists: false, corrupted: false });
+});
+
+test('global: status válido informa versões e integridade', () => {
+  const paths = fixture();
+  const installed = installGlobal({ paths });
+  const status = globalStatus({ paths });
+
+  assert.equal(status.exists, true);
+  assert.equal(status.corrupted, false);
+  assert.equal(status.installedVersion, installed.version);
+  assert.equal(status.packageVersion, installed.version);
+  assert.equal(status.path, paths.current);
+});
+
+test('global: status detecta cache corrompido', () => {
+  const paths = fixture();
+  installGlobal({ paths });
+  writeFileSync(join(paths.current, 'installation.json'), '{invalido', 'utf8');
+
+  assert.equal(globalStatus({ paths }).corrupted, true);
+});
+
+function requireDirectoryEntries(directory) {
+  return existsSync(directory) ? readdirSync(directory) : [];
+}


### PR DESCRIPTION
## Summary

Adds an optional global installation mode for Mira Animator.

## Changes

- Adds `mira global install`
- Adds `mira global update`
- Adds `mira global status`
- Stores the global installation under `~/.mira`
- Uses atomic publication with rollback on failure
- Preserves all existing local commands and behavior
- Adds coverage for installation, update, status, rollback and cleanup failures

## Validation

- 209 tests passing
- No regressions in the existing local installation flow